### PR TITLE
Fix infinite loop during slot cleanup for read-only properties

### DIFF
--- a/tools/repc/utils.cpp
+++ b/tools/repc/utils.cpp
@@ -124,6 +124,7 @@ static QVector<FunctionDef> cleanedSlotList(const ClassDef &cdef)
                     ret.erase(it);
                     break;
                 }
+                it++;
             }
         }
     }


### PR DESCRIPTION
The while loop in the function cleanedSlotList has never incremented the
iterator which resulted in an infinite loop.