### PR TITLE
Also reconnect on QLocalSocket::PeerClosedError

### DIFF
--- a/src/remoteobjects/qconnection_local_backend.cpp
+++ b/src/remoteobjects/qconnection_local_backend.cpp
@@ -94,6 +94,7 @@ void LocalClientIo::onError(QLocalSocket::LocalSocketError error)
     switch (error) {
     case QLocalSocket::ServerNotFoundError:
     case QLocalSocket::UnknownSocketError:
+    case QLocalSocket::PeerClosedError:
         //Host not there, wait and try again
         emit shouldReconnect(this);
         break;


### PR DESCRIPTION
I had the issue, that after restarting a QtRemoteObjects server (source) twice, that the client (replica) wasn't reconnecting.

This can easily be reproduced with the *simpleswitch* example:
1. Start directconnectclient
2. Start directconnectserver
3. Restart directconnectserver
4. Restart directocnnectserver

Enabling QtRemoteObjects debug logging categories, helped me to see that QLocalSocket::PeerClosedError didn't lead to a reconnect request.

Is this for a specific reason? If not, I am happy to see this merged.
